### PR TITLE
feat: Add category shuffle feature to match template

### DIFF
--- a/.changeset/nasty-points-burn.md
+++ b/.changeset/nasty-points-burn.md
@@ -1,0 +1,5 @@
+---
+"anki-templates": patch
+---
+
+feat: Add category shuffle feature to match template

--- a/docs/match.md
+++ b/docs/match.md
@@ -11,6 +11,7 @@ Notes for `items`
 
 - Each line starts with a category, followed by two colons separating it from the items under that category
 - Each item is separated by two commas
+- Categories and items are shuffled to enhance active recall
 
 An example:
 

--- a/src/entries/match.tsx
+++ b/src/entries/match.tsx
@@ -228,10 +228,15 @@ export default () => {
       );
   }, []);
 
+  const [shuffledCollections, setShuffledCollections] = useCrossState(
+    'shuffled-collections',
+    () => shuffle(collections),
+  );
+
   return (
     <CardShell
       title={t.question}
-      questionExtra={<Playground collections={collections} />}
+      questionExtra={<Playground collections={shuffledCollections} />}
       answer={
         hasNote ? (
           <AnkiField

--- a/src/entries/match.tsx
+++ b/src/entries/match.tsx
@@ -228,9 +228,8 @@ export default () => {
       );
   }, []);
 
-  const [shuffledCollections] = useCrossState(
-    'shuffled-collections',
-    () => shuffle(collections),
+  const [shuffledCollections] = useCrossState('shuffled-collections', () =>
+    shuffle(collections),
   );
 
   return (

--- a/src/entries/match.tsx
+++ b/src/entries/match.tsx
@@ -228,7 +228,7 @@ export default () => {
       );
   }, []);
 
-  const [shuffledCollections, setShuffledCollections] = useCrossState(
+  const [shuffledCollections] = useCrossState(
     'shuffled-collections',
     () => shuffle(collections),
   );


### PR DESCRIPTION
Fixes #88

Add category shuffle feature to match template

* Use `useCrossState` to store and retrieve the shuffled order of categories in `src/entries/match.tsx`
* Shuffle the `collections` array before passing it to the `Playground` component in `src/entries/match.tsx`
* Update `docs/match.md` to mention the new category shuffling feature

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ikkz/anki-template/pull/89?shareId=4b9ec2cf-a656-486b-ba86-9a9f12305b16).